### PR TITLE
Fix error message in collinearity check

### DIFF
--- a/R/amcheck.r
+++ b/R/amcheck.r
@@ -963,7 +963,7 @@ amcheck <- function(x,m=5,p2s=1,frontend=FALSE,idvars=NULL,logs=NULL,
     lmcheck <- lm(I(rnorm(AMn))~ ., data = as.data.frame(x[,idcheck, drop = FALSE]))
   }
   if (any(is.na(coef(lmcheck)))) {
-    bad.var <- names(x[,idcheck])[which(is.na(coef(lmcheck))) - 1]
+    bad.var <- colnames(x[,idcheck])[which(is.na(coef(lmcheck))) - 1]
     bar.var <- paste(bad.var, collapse = ", ")
     stop(paste("The variable ",bad.var,"is perfectly collinear with another variable in the data.\n"))
   }


### PR DESCRIPTION
Previously, the error message searched `names(x)` to retrieve the variable name, which works if `x` is a data frame but not if it is a matrix. `colnames(x)` works in both settings.

Reproducible example of the bug fixed:

```
R> mat <- cbind(x = 1:10, y = 1:10, z = c(rnorm(9), NA))
R> mat
       x  y        z
 [1,]  1  1 -1.76707
 [2,]  2  2  1.76927
 [3,]  3  3  0.87793
 [4,]  4  4 -0.34865
 [5,]  5  5  0.61256
 [6,]  6  6 -0.85440
 [7,]  7  7 -0.91579
 [8,]  8  8 -1.13663
 [9,]  9  9  1.03717
[10,] 10 10       NA
R> amelia(mat)
Error in amcheck(x = x, m = m, idvars = numopts$idvars, priors = priors,  : 
  The variable   is perfectly collinear with another variable in the data.
R> amelia(as.data.frame(mat))
Error in amcheck(x = x, m = m, idvars = numopts$idvars, priors = priors,  : 
  The variable  y is perfectly collinear with another variable in the data.
```