### PR TITLE
Don't throw error for no cs if plotall specified

### DIFF
--- a/R/diag.r
+++ b/R/diag.r
@@ -597,7 +597,7 @@ tscsPlot <- function(output, var, cs, draws = 100, conf = .90,
                      pch, ylim, xlim, frontend = FALSE, plotall=FALSE, nr, nc, pdfstub, ...) {
   if (missing(var))
     stop("I don't know which variable (var) to plot")
-  if (missing(cs))
+  if (missing(cs) && !plotall)
     stop("case name (cs) is not specified")
   if (is.null(output$arguments$ts) || is.null(output$arguments$cs))
     stop("both 'ts' and 'cs' need to be set in the amelia output")


### PR DESCRIPTION
Another one-liner fix: Previously, `tscsPlot()` would always throw an error if the `cs` argument were missing.  Now, if `plotall = TRUE`, in which case `cs` is overwritten anyway, it doesn't throw an error.