### PR TITLE
fix bugs with [ code assuming that drop = TRUE

### DIFF
--- a/R/prep.r
+++ b/R/prep.r
@@ -191,7 +191,7 @@ frame.to.matrix<-function(x,idvars) {
   if (length(char.vars) > 0)
     for (i in char.vars)
       if (is.na(match(i,idvars)))
-        x[,i]<-as.factor(x[,i])         #changes cs/noms char. vars to factors
+        x[,i]<-as.factor(x[[i]])         #changes cs/noms char. vars to factors
       else
         x[,i]<-1                        #junks id char vars.
 


### PR DESCRIPTION
This fixes some, but not all of the cases, in which `[` is used to extract a single column from a data frame as a vector, and assumes that the value of the `drop` argument is `TRUE`. I got this bug when using a `data_frame` class from **dplyr**, because the `[.data_frame` method always returns a `data_frame` and does not drop dimensions. I fixed a few of the instances by replacing some problematic cases of `[,i]` with `[[i]]`, but the idiom of extracting a single column with code similar to `[,i]` seems to be used throughout the code base. 
