### PR TITLE
Fix build with Rtools40.

### DIFF
--- a/vignettes/Makefile
+++ b/vignettes/Makefile
@@ -6,11 +6,11 @@ all:	amelia.pdf
 	echo "Sweave(\"\$<\", debug=TRUE, eval=\$(REVAL))" | R --slave
 
 %.pdf:	%.tex
-	pdflatex \$*
-	bibtex \$*
-	pdflatex \$*
-	pdflatex \$*
-	pdflatex \$*
+	pdflatex $*
+	bibtex $*
+	pdflatex $*
+	pdflatex $*
+	pdflatex $*
 
 clean: 
 	rm -rf *.aux *.tex *.bbl *.blg *.bcf *.log *.out *.rel *.toc amelia-*.pdf Rplots.pdf


### PR DESCRIPTION
We are about to roll out a new tooclhain for R on Windows and the Amelia package errors when building the vignette: https://cran.r-project.org/web/checks/check_results_Amelia.html

The culprit seems to be escape characters in [vignette/Makefile](vignette/Makefile) which the new version of `make` does not like. I don't think it is needed to escape `$` in make, so the current PR fixes the problem. You can confirm this by uploading your package to `R-devel ATC (alternative toolchain)` on winbuilder: http://win-builder.r-project.org/upload.aspx

Alternatively, I think you could remove the custom  `vignette/Makefile` altogether, because it seems that it does exactly the same thing as what R does by default.

Could you please submit a fix to CRAN? We need to get our fail list down asap to move forward with the new toolchain.







